### PR TITLE
Bump Ardalis.GuardClauses from 4.5.0 to 5.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Ardalis.ApiEndpoints" Version="4.1.0" />
-    <PackageVersion Include="Ardalis.GuardClauses" Version="4.5.0" />
+    <PackageVersion Include="Ardalis.GuardClauses" Version="5.0.0" />
     <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="8.0.0" />
     <PackageVersion Include="Ardalis.Result" Version="10.1.0" />
     <PackageVersion Include="Ardalis.Specification" Version="8.0.0" />


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: Ardalis.GuardClauses dependency-version: 5.0.0 dependency-type: direct:production update-type: version-update:semver-major ...